### PR TITLE
Fix MissingMethodException on mod menu creation

### DIFF
--- a/BossAttacks/ModMenu.cs
+++ b/BossAttacks/ModMenu.cs
@@ -9,6 +9,8 @@ namespace BossAttacks
     {
         public bool ToggleButtonInsideMenu => true;
 
+        public string GetMenuButtonText() => $"Boss Attacks";
+
         public MenuScreen GetMenuScreen(MenuScreen modListMenu, ModToggleDelegates? toggle)
         {
             _menuRef = new Menu("Boss Attacks", new Element[]
@@ -41,7 +43,6 @@ namespace BossAttacks
 #endif
             });
 
-            _menuRef.SetMenuButtonNameAndDesc(BossAttacks.Instance, "Boss Attacks");
             return _menuRef.GetMenuScreen(modListMenu);
         }
 


### PR DESCRIPTION
Due to a Satchel update the SetMenuButtonNameAndDesc function no longer exists, this causes a `MissingMethodException` when the mapi tries to create the mod menu. But since the method in this case is only used to change the name of the button and not description the behaviour can be replicated by implementing a custom GetMenuButtonText method.